### PR TITLE
Additional Request Objects for inclusion of payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.zip
 *.tar.gz
 *.rar
+*.iml
 
 /ces-common-clients/target/
 /ces-common-clients/nbproject/
@@ -31,3 +32,4 @@ leap-ces-common-clients/.classpath
 .settings/org.eclipse.jdt.core.prefs
 .settings/org.eclipse.m2e.core.prefs
 .vscode/settings.json
+.idea/**

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <name>leap-ces-clients</name>
     <build>

--- a/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/ces/PatientConsentConsultHookRequestWithData.java
+++ b/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/ces/PatientConsentConsultHookRequestWithData.java
@@ -1,0 +1,36 @@
+package gov.hhs.onc.leap.ces.common.clients.model.ces;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import gov.hhs.onc.leap.ces.common.clients.model.card.PatientConsentConsultHookRequest;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"hookRequest", "payload"})
+public class PatientConsentConsultHookRequestWithData {
+
+    @JsonProperty("hookRequest")
+    private PatientConsentConsultHookRequest hookRequest;
+    @JsonProperty("payload")
+    private String payload;
+
+    @JsonProperty("hookRequest")
+    public PatientConsentConsultHookRequest getHookRequest() {
+        return hookRequest;
+    }
+
+    @JsonProperty("hookRequest")
+    public void setHookRequest(PatientConsentConsultHookRequest hookRequest) {
+        this.hookRequest = hookRequest;
+    }
+
+    @JsonProperty("payload")
+    public String getPayload() {
+        return payload;
+    }
+
+    @JsonProperty("payload")
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+}

--- a/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/ces/PatientConsentConsultXacmlRequestWithData.java
+++ b/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/ces/PatientConsentConsultXacmlRequestWithData.java
@@ -1,0 +1,38 @@
+package gov.hhs.onc.leap.ces.common.clients.model.ces;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import gov.hhs.onc.leap.ces.common.clients.model.xacml.XacmlRequest;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"xacmlRequest", "payload"})
+public class PatientConsentConsultXacmlRequestWithData {
+
+    @JsonProperty("xacmlRequest")
+    private XacmlRequest xacmlRequest;
+
+    @JsonProperty("payload")
+    private String payload;
+
+    @JsonProperty("xacmlRequest")
+    public XacmlRequest getXacmlRequest() {
+        return xacmlRequest;
+    }
+
+    @JsonProperty("xacmlRequest")
+    public void setXacmlRequest(XacmlRequest xacmlRequest) {
+        this.xacmlRequest = xacmlRequest;
+    }
+
+    @JsonProperty("payload")
+    public String getPayload() {
+        return payload;
+    }
+
+    @JsonProperty("payload")
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+}

--- a/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/generic/CESRequest.java
+++ b/src/main/java/gov/hhs/onc/leap/ces/common/clients/model/generic/CESRequest.java
@@ -16,7 +16,7 @@ import gov.hhs.onc.leap.ces.common.clients.model.xacml.XacmlRequest;
 import gov.hhs.onc.leap.ces.common.clients.model.card.Actor;
 import gov.hhs.onc.leap.ces.common.clients.model.card.Context;
 
-import gov.hhs.onc.leap.ces.common.clients.model.generic.CESRequest;
+
 import gov.hhs.onc.leap.ces.common.clients.model.card.PatientConsentConsultHookRequest;
 import gov.hhs.onc.leap.ces.common.clients.model.card.PatientId;
 


### PR DESCRIPTION
This addresses 2 issues
1) Integration with eHealth eXchange DocumentRetrieve and DocumentSubmit functionality requires CES to have knowledge of both the Consent decision and outcome of SLS actions to properly log events
2) Java version issues with CONNECT stack, built to 1.7, required changes to client build